### PR TITLE
Fix enums generating with double quotes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>go-rest-server-openapi-generator</artifactId>
     <packaging>jar</packaging>
     <name>go-rest-server-openapi-generator</name>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/resources/go-rest-server/model.mustache
+++ b/src/main/resources/go-rest-server/model.mustache
@@ -20,7 +20,7 @@ type {{{name}}} {{^format}}{{dataType}}{{/format}}{{#format}}{{{format}}}{{/form
 const (
 	{{#allowableValues}}
 	{{#enumVars}}
-	{{name}} {{{classname}}} = "{{{value}}}"
+	{{name}} {{{classname}}} = {{{value}}}
 	{{/enumVars}}
 	{{/allowableValues}}
 ){{/isEnum}}{{^isEnum}}{{#description}}


### PR DESCRIPTION
Fix enums generating with values like ""value"" which is invalid in go.