### PR TITLE
Further fixes for nullable validation generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>go-rest-server-openapi-generator</artifactId>
     <packaging>jar</packaging>
     <name>go-rest-server-openapi-generator</name>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/resources/go-rest-server/partial_model_field.mustache
+++ b/src/main/resources/go-rest-server/partial_model_field.mustache
@@ -5,6 +5,9 @@
 {{/vendorExtensions.x-go-mongo-id}}
 {{^vendorExtensions.x-go-mongo-id}}
     // {{nameInCamelCase}} {{description}}
+    {{#deprecated}}
+      // Deprecated
+    {{/deprecated}}
     {{#isFreeFormObject}}
     {{nameInCamelCase}} map[string]interface{} `json:"{{baseName}}{{^required}},omitempty{{/required}}"{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
     {{/isFreeFormObject}}{{^isFreeFormObject}}

--- a/src/main/resources/go-rest-server/partial_model_validates_number.mustache
+++ b/src/main/resources/go-rest-server/partial_model_validates_number.mustache
@@ -1,10 +1,10 @@
 {{#minium}}
-    if m.{{name}} < {{minium}} {
+    if {{#isNullable}}m.{{name}} != nil && *{{/isNullable}}m.{{name}} < {{minium}} {
         errs.Append(fmt.Errorf("{{name}} must be greater than {{minium}}"))
     }
 {{/minium}}
 {{#maximum}}
-    if m.{{name}} > {{maximum}} {
+    if {{#isNullable}}m.{{name}} != nil && *{{/isNullable}}m.{{name}} > {{maximum}} {
         errs.Append(fmt.Errorf("{{name}} must be less than {{maximum}}"))
     }
 {{/maximum}}

--- a/src/main/resources/go-rest-server/partial_model_validates_string.mustache
+++ b/src/main/resources/go-rest-server/partial_model_validates_string.mustache
@@ -1,19 +1,21 @@
 {{#required}}
-    if m.{{name}} == "" {
+    if {{#isNullable}}m.{{name}} == nil || {{/isNullable}}m.{{name}} == "" {
         errs.Append(fmt.Errorf("{{name}} is required"))
     }
 {{/required}}
 {{#minLength}}
-    if len(m.{{name}}) < {{minLength}} {
+    if {{#isNullable}}m.{{name}} != nil && {{/isNullable}}len({{#isNullable}}*{{/isNullable}}m.{{name}}) < {{minLength}} {
         errs.Append(fmt.Errorf("{{name}} should have minimum length of {{minLength}}"))
     }
 {{/minLength}}
 {{#maxLength}}
-    if len(m.{{name}}) > {{maxLength}} {
+    if {{#isNullable}}m.{{name}} != nil && {{/isNullable}}len({{#isNullable}}*{{/isNullable}}m.{{name}}) > {{maxLength}} {
         errs.Append(fmt.Errorf("{{name}} exceed maximum length {{maxLength}}"))
     }
-{{/maxLength}}{{#isEnum}}
+{{/maxLength}}
+{{#isEnum}}
     // {{name}} isEnum
-    if m.{{name}} != "" && !validate.IsAllowedValue(m.{{name}}, []string { {{#allowableValues}}{{#enumVars}}{{{value}}},{{/enumVars}}{{/allowableValues}} }) {
+    if {{#isNullable}}m.{{name}} != nil && {{/isNullable}}m.{{name}} != "" && !validate.IsAllowedValue({{#isNullable}}*{{/isNullable}}m.{{name}}, []string { {{#allowableValues}}{{#enumVars}}{{{value}}},{{/enumVars}}{{/allowableValues}} }) {
         errs.Append(fmt.Errorf("{{name}} value not allowed: %s", m.{{name}}))
-    }{{/isEnum}}
+    }
+{{/isEnum}}


### PR DESCRIPTION
More fixes to the string and number validation handlers for nullable fields.

Also copied over the deprecated comment support from upstream templates.